### PR TITLE
36 version 2

### DIFF
--- a/contracts/CommunityCoin.sol
+++ b/contracts/CommunityCoin.sol
@@ -12,6 +12,8 @@ contract CommunityCoin is CommunityCoinBase {
     * @param communityCoinInstanceAddr address of contract that managed and cloned pools
     * @param discountSensitivity_ discountSensitivity value that manage amount tokens in redeem process. multiplied by `FRACTION`(10**5 by default)
     * @param rolesManagementAddr_ contract that would will manage roles(admin,redeem,circulate)
+    * @param reserveToken_ address of reserve token. like a WETH, USDT,USDC, etc.
+    * @param tradedToken_ address of traded token. usual it intercoin investor token
     * @custom:calledby StakingFactory contract 
     * @custom:shortd initializing contract. called by StakingFactory contract
     */
@@ -21,13 +23,15 @@ contract CommunityCoin is CommunityCoinBase {
         address hook_,
         address communityCoinInstanceAddr,
         uint256 discountSensitivity_,
-        address rolesManagementAddr_
+        address rolesManagementAddr_,
+        address reserveToken_,
+        address tradedToken_
     ) 
         initializer 
         external 
         virtual
         override 
     {
-        CommunityCoinBase__init("Staking Tokens", "STAKE", impl, implErc20, hook_, communityCoinInstanceAddr, discountSensitivity_, rolesManagementAddr_);
+        CommunityCoinBase__init("Staking Tokens", "STAKE", impl, implErc20, hook_, communityCoinInstanceAddr, discountSensitivity_, rolesManagementAddr_, reserveToken_, tradedToken_);
     }
 }

--- a/contracts/CommunityCoinFactory.sol
+++ b/contracts/CommunityCoinFactory.sol
@@ -34,6 +34,9 @@ contract CommunityCoinFactory is Ownable {
     */
     address public immutable rolesManagementImplementation;
 
+    address public immutable reserveToken;
+    address public immutable tradedToken;
+
     address[] public instances;
     
     event InstanceCreated(address instance, uint instancesCount);
@@ -44,13 +47,17 @@ contract CommunityCoinFactory is Ownable {
     * @param stakingPoolImpl address of StakingPool implementation
     * @param stakingPoolImplErc20 address of StakingPoolErc20 implementation
     * @param rolesManagementImpl address of RolesManagement implementation
+    * @param reserveToken_ address of reserve token. like a WETH, USDT,USDC, etc.
+    * @param tradedToken_ address of traded token. usual it intercoin investor token
     */
     constructor(
         address communityCoinImpl,
         address communityStakingPoolFactoryImpl,
         address stakingPoolImpl,
         address stakingPoolImplErc20,
-        address rolesManagementImpl
+        address rolesManagementImpl,
+        address reserveToken_,
+        address tradedToken_
     ) 
     {
         communityCoinImplementation = communityCoinImpl;
@@ -58,6 +65,8 @@ contract CommunityCoinFactory is Ownable {
         stakingPoolImplementation = stakingPoolImpl;
         stakingPoolErc20Implementation = stakingPoolImplErc20;
         rolesManagementImplementation = rolesManagementImpl;
+        reserveToken = reserveToken_;
+        tradedToken = tradedToken_;
         
     }
 
@@ -112,7 +121,7 @@ contract CommunityCoinFactory is Ownable {
 
         ICommunityRolesManagement(rolesManagementClone).initialize(communitySettings, instance);
 
-        ICommunityCoin(instance).initialize(stakingPoolImplementation, stakingPoolErc20Implementation, hook, coinInstancesClone, discountSensitivity, rolesManagementClone);
+        ICommunityCoin(instance).initialize(stakingPoolImplementation, stakingPoolErc20Implementation, hook, coinInstancesClone, discountSensitivity, rolesManagementClone, reserveToken, tradedToken);
         
         Ownable(instance).transferOwnership(_msgSender());
         

--- a/contracts/CommunityStakingPool.sol
+++ b/contracts/CommunityStakingPool.sol
@@ -345,15 +345,20 @@ contract CommunityStakingPool is CommunityStakingPoolBase, ICommunityStakingPool
         internal 
         returns(uint256 amountOut) 
     {
-        require(IERC20Upgradeable(tokenIn).approve(address(uniswapRouter), amountIn), "APPROVE_FAILED");
-        address[] memory path = new address[](2);
-        path[0] = address(tokenIn);
-        path[1] = address(tokenOut);
-        // amountOutMin is set to 0, so only do this with pairs that have deep liquidity
-        uint256[] memory outputAmounts = UniswapV2Router02.swapExactTokensForTokens(
-            amountIn, 0, path, address(this), block.timestamp
-        );
-        amountOut = outputAmounts[1];
+        if (tokenIn == tokenOut) {
+            // situation when WETH is a reserve token
+            amountOut = amountIn;
+        } else {
+            require(IERC20Upgradeable(tokenIn).approve(address(uniswapRouter), amountIn), "APPROVE_FAILED");
+            address[] memory path = new address[](2);
+            path[0] = address(tokenIn);
+            path[1] = address(tokenOut);
+            // amountOutMin is set to 0, so only do this with pairs that have deep liquidity
+            uint256[] memory outputAmounts = UniswapV2Router02.swapExactTokensForTokens(
+                amountIn, 0, path, address(this), block.timestamp
+            );
+            amountOut = outputAmounts[1];
+        }
     }
     
     function _sellTradedAndStake(

--- a/contracts/interfaces/ICommunityCoin.sol
+++ b/contracts/interfaces/ICommunityCoin.sol
@@ -9,7 +9,9 @@ interface ICommunityCoin {
         address hook,
         address instancesImpl,
         uint256 discountSensitivity,
-        address rolesManagementClone
+        address rolesManagementClone,
+        address reserveToken,
+        address tradedToken
     ) external;
 
     event InstanceCreated(address indexed tokenA, address indexed tokenB, address instance);

--- a/test/test.js
+++ b/test/test.js
@@ -1513,19 +1513,47 @@ describe("Staking contract tests", function () {
                     }); 
                 });
                 describe("should unstake", function () {
-                    it("successfull", async () => {
+                        var uniswapV2PairInstance;
+                    beforeEach("before each callback", async() => {
+                        let uniswapV2PairAddress = await communityStakingPool.uniswapV2Pair();
+                        uniswapV2PairInstance = await ethers.getContractAt("ERC20Mintable",uniswapV2PairAddress);
+                    });
+                    it("successfull ", async () => {
                         // pass some mtime
                         await time.increase(lockupIntervalCount*dayInSeconds+9);    
-                        
+
+                        let bobLPTokenBefore = await uniswapV2PairInstance.balanceOf(bob.address);
                         let bobReservedTokenBefore = await erc20ReservedToken.balanceOf(bob.address);
                         let bobTradedTokenBefore = await erc20TradedToken.balanceOf(bob.address);
 
                         await CommunityCoin.connect(bob).approve(CommunityCoin.address, shares);
                         await CommunityCoin.connect(bob)["unstake(uint256)"](shares);
 
+                        let bobLPTokenAfter = await uniswapV2PairInstance.balanceOf(bob.address);
+                        let bobReservedTokenAfter = await erc20ReservedToken.balanceOf(bob.address);
+                        let bobTradedTokenAfter = await erc20TradedToken.balanceOf(bob.address);
+                        
+                        expect(bobLPTokenAfter).gt(bobLPTokenBefore);
+                        expect(bobReservedTokenAfter).eq(bobReservedTokenBefore);
+                        expect(bobTradedTokenAfter).eq(bobTradedTokenBefore);
+
+                    });
+                    it("successfull RRL", async () => {
+                        // pass some mtime
+                        await time.increase(lockupIntervalCount*dayInSeconds+9);    
+                        
+                        let bobLPTokenBefore = await uniswapV2PairInstance.balanceOf(bob.address);
+                        let bobReservedTokenBefore = await erc20ReservedToken.balanceOf(bob.address);
+                        let bobTradedTokenBefore = await erc20TradedToken.balanceOf(bob.address);
+
+                        await CommunityCoin.connect(bob).approve(CommunityCoin.address, shares);
+                        await CommunityCoin.connect(bob)["unstakeAndRemoveLiquidity(uint256)"](shares);
+
+                        let bobLPTokenAfter = await uniswapV2PairInstance.balanceOf(bob.address);
                         let bobReservedTokenAfter = await erc20ReservedToken.balanceOf(bob.address);
                         let bobTradedTokenAfter = await erc20TradedToken.balanceOf(bob.address);
 
+                        expect(bobLPTokenAfter).eq(bobLPTokenBefore);
                         expect(bobReservedTokenAfter).gt(bobReservedTokenBefore);
                         expect(bobTradedTokenAfter).gt(bobTradedTokenBefore);
                     });


### PR DESCRIPTION
was made some refactor:
- uniswap pool are the one and specify ibn constructor CommunityCoinFactory
- so Staking Pools have the same pair traded-reserved tokens with different duration
- fixed method `unstake`
- added method `unstakeAndRemoveLiquidity`
- 